### PR TITLE
Use vim.tbl_isempty() for checking result

### DIFF
--- a/lua/ddc_nvim_lsp.lua
+++ b/lua/ddc_nvim_lsp.lua
@@ -25,7 +25,7 @@ end
 
 local request_candidates = function(arguments, id)
   local map = vim.lsp.buf_request(0, 'textDocument/completion', arguments, function(_, arg1, arg2) get_candidates(id, _, arg1, arg2) end)
-  if not map or #map == 0 then
+  if not map or vim.tbl_isempty(map) then
     api.nvim_call_function('ddc#callback', {id, {
       result = {},
       success = false,


### PR DESCRIPTION
Though I don't know why, sometimes `#map` returns 0 despite the request succeeded and `map` is not empty.
It seems that `vim.tbl_isempty()` can ckeck if the table is really empty.