### PR TITLE
Add a new source parameter: `snippetIndicator`

### DIFF
--- a/denops/@ddc-sources/nvim-lsp.ts
+++ b/denops/@ddc-sources/nvim-lsp.ts
@@ -54,6 +54,7 @@ export type Params = {
   enableResolveItem: boolean;
   enableAdditionalTextEdit: boolean;
   confirmBehavior: ConfirmBehavior;
+  snippetIndicator: string;
 };
 
 function isDefined<T>(x: T | undefined): x is T {
@@ -95,6 +96,7 @@ export class Source extends BaseSource<Params> {
         args.completePos,
         args.completePos + args.completeStr.length,
         cursorLine,
+        args.sourceParams.snippetIndicator,
       );
 
       const completionList = Array.isArray(result)
@@ -245,6 +247,7 @@ export class Source extends BaseSource<Params> {
       enableResolveItem: false,
       enableAdditionalTextEdit: false,
       confirmBehavior: "insert",
+      snippetIndicator: "~",
     };
   }
 }

--- a/denops/ddc-source-nvim-lsp/completion_item.ts
+++ b/denops/ddc-source-nvim-lsp/completion_item.ts
@@ -51,6 +51,7 @@ export class CompletionItem {
   #suggestCharacter: number;
   #requestCharacter: number;
   #cursorLine: number;
+  #snippetIndicator: string;
 
   static isSnippet(
     lspItem: LSP.CompletionItem,
@@ -175,6 +176,7 @@ export class CompletionItem {
     suggestCharacter: number,
     requestCharacter: number,
     cursorLine: number,
+    snippetIndicator: string,
   ) {
     this.#clientId = clientId;
     this.#offsetEncoding = offsetEncoding;
@@ -183,6 +185,7 @@ export class CompletionItem {
     this.#suggestCharacter = suggestCharacter;
     this.#requestCharacter = requestCharacter;
     this.#cursorLine = cursorLine;
+    this.#snippetIndicator = snippetIndicator;
   }
 
   toDdcItem(
@@ -294,7 +297,7 @@ export class CompletionItem {
     lspItem: LSP.CompletionItem,
   ): { abbr: string; highlights?: PumHighlight[] } {
     const abbr = lspItem.insertTextFormat === LSP.InsertTextFormat.Snippet
-      ? `${lspItem.label}~`
+      ? `${lspItem.label}${this.#snippetIndicator}`
       : lspItem.label;
     return {
       abbr,

--- a/denops/ddc-source-nvim-lsp/completion_item_test.ts
+++ b/denops/ddc-source-nvim-lsp/completion_item_test.ts
@@ -9,6 +9,7 @@ const params: Params = {
   enableResolveItem: false,
   enableAdditionalTextEdit: true,
   confirmBehavior: "insert",
+  snippetIndicator: "~",
 };
 
 const ClientId = 0 as const satisfies number;
@@ -33,6 +34,7 @@ async function setup(args: {
     completePos,
     completePos + args.input.length,
     row - 1,
+    "~",
   );
   const ddcItem = completionItem.toDdcItem(args.lspItem);
   if (ddcItem === undefined) {

--- a/doc/ddc-source-nvim-lsp.txt
+++ b/doc/ddc-source-nvim-lsp.txt
@@ -108,6 +108,15 @@ snippetEngine		(string | function)
 <
 		Default: ""
 
+				*ddc-source-nvim-lsp-param-snippetIndicator*
+snippetIndicator		(string)
+		The indicator string for snippet items added to the end of
+		a completion item.
+
+		NOTE: This affects ddc-item-attribute-abbr.
+
+		Default: "~"
+
 				*ddc-source-nvim-lsp-param-enableResolveItem*
 enableResolveItem	(boolean)
 		Enable LSP's "completionItem/resolve" feature.


### PR DESCRIPTION
### What

- Add the `snippetIndicator` parameter to change the indicator string for snippet completion candidates.

### Why

With recent (huge 👏) updates, now `ddc-source-nvim-lsp` adds an indicator string: `~`, to snippet completion candidates. While it should work well for the majority of users, I think there might be a user who wants to change this string (in my case, I just want to remove `~`).

Given that, this PR adds a new source parameter named `snippetIndicator` that enables us to change the indicator string for snippet completion candidates to an arbitrary string (including an empty string).