### PR TITLE
fix: Timeout of `completionItem/resolve` is not handled

### DIFF
--- a/lua/ddc_nvim_lsp/internal.lua
+++ b/lua/ddc_nvim_lsp/internal.lua
@@ -101,7 +101,7 @@ function M.log(client_name, err)
   end
 
   if type(err) == "string" then
-    vim.notify(("%s: %s"):format(client_name, err))
+    vim.notify(("%s: %s"):format(client_name, err), vim.log.levels.ERROR)
   else
     vim.notify(
       ("%s: %s: %s"):format(client_name, lsp.ErrorCodes[err.code] or err.code, err.message),


### PR DESCRIPTION
## Problem

 Source.getPreviewer throws null reference errors when `completionItem/resolve` requests failed by timeout.

## Solution

 Add a handling of errors.